### PR TITLE
Activate possibility of missing-tiles below spawn

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -78,7 +78,11 @@ Map = function (tmx)
         end
 
         missing_tiles_glitch.generate_glitches(glitch_options.missing)
-        missing_tiles_glitch.modify_layer(start_x)
+        if glitch_lvl < 4 then
+            missing_tiles_glitch.modify_layer(start_x)
+        else
+            missing_tiles_glitch.modify_layer()
+        end
 
         missing_dtiles_glitch.generate_glitches(glitch_options.dmissing, "single")
         missing_dtiles_glitch.modify_layer(start_x)


### PR DESCRIPTION
On the 4th and subsequent glitch-outs, missing tile glitches can occur
below the spawn tiles. This means that it should be theoretically
impossible to get stuck at the spawn point, surrounded by glitches,
incapable of dying
